### PR TITLE
Support Atmel SAM3X8E (Arduino Due)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This Library gets the Unique Serial ID from the AVR Microcontroller and ESP Microcontroller.
 
-# AVR Microcontroller
+# Atmel AVR Microcontroller
 
 ## Unique Serial ID - Hidden Serial Number
 
@@ -32,7 +32,15 @@ Apparently, the chip Atmega328p have a hidden serial number with 9 bytes, and ot
 * Atmega2560 - 9 bytes
 * Attiny85 - 9 bytes
 
-# ESP Microcontroller
+# Atmel SAM ARM Microcontroller
+Atmel SAM3X8E is used in Arduino Due. The Unique Identifier is located in the first 128 bits of the Flash memory mapping. So, at the address 0x400000-0x400003.
+"Each device integrates its own 128-bit unique identifier. These bits are factory configured and cannot be changed by the user. The ERASE pin has no effect on the unique identifier." (http://ww1.microchip.com/downloads/en/devicedoc/atmel-11057-32-bit-cortex-m3-microcontroller-sam3x-sam3a_datasheet.pdf)
+
+## Tested Microcontroller
+
+* Atmel SAM3X8E ARM Cortex-M3 - 16 bytes
+
+# Espressif ESP Microcontroller
 
 ESP microcontroller has basically two versions, ESP8266 and ESP32, each one has a specific function to request the chip id. <br/>
 

--- a/library.properties
+++ b/library.properties
@@ -1,10 +1,10 @@
 name=ArduinoUniqueID
-version=1.0.5
+version=1.0.6
 author=Luiz Henrique Cassettari
 maintainer=Luiz Henrique Cassettari <ricaun@gmail.com>
 sentence=Arduino Library to get the AVR microcontroler Unique ID / Manufacture Serial Number.
-paragraph=The ArduinoUniqueID Library use the buildin feature to select the manufacture serial number from the microcontroler. Suported microcontroler: Atmega328pb, Atmega328p, Atmega2560, Attiny85, ESP8266 & ESP32.
+paragraph=The ArduinoUniqueID Library use the buildin feature to select the manufacture serial number from the microcontroler. Suported microcontroler: Atmega328pb, Atmega328p, Atmega2560, Attiny85, SAM3X8E, ESP8266 & ESP32.
 category=Other
 url=https://github.com/ricaun/ArduinoUniqueID
-architectures=avr, esp8266, esp32
+architectures=avr, esp8266, esp32, sam
 includes=ArduinoUniqueID.h

--- a/src/ArduinoUniqueID.cpp
+++ b/src/ArduinoUniqueID.cpp
@@ -31,6 +31,40 @@ ArduinoUniqueID::ArduinoUniqueID()
 	id[5] = chipid >> 24;
 	id[6] = chipid >> 32;
 	id[7] = chipid >> 40;
+
+#elif defined(ARDUINO_ARCH_SAM)
+	unsigned int status ;
+	/* Send the Start Read unique Identifier command (STUI) by writing the Flash Command Register with the STUI command.*/
+	EFC1->EEFC_FCR = (0x5A << 24) | EFC_FCMD_STUI;
+	do
+	{
+		status = EFC1->EEFC_FSR ;
+	} while ( (status & EEFC_FSR_FRDY) == EEFC_FSR_FRDY ) ;
+
+	/* The Unique Identifier is located in the first 128 bits of the Flash memory mapping. So, at the address 0x400000-0x400003. */
+	uint32_t pdwUniqueID[4];
+	pdwUniqueID[0] = *(uint32_t *)IFLASH1_ADDR;
+	pdwUniqueID[1] = *(uint32_t *)(IFLASH1_ADDR + 4);
+	pdwUniqueID[2] = *(uint32_t *)(IFLASH1_ADDR + 8);
+	pdwUniqueID[3] = *(uint32_t *)(IFLASH1_ADDR + 12);
+	for (int i = 0; i < 4; i++)
+	{
+		id[i*4+0] = (uint8_t)(pdwUniqueID[i] >> 24);
+		id[i*4+1] = (uint8_t)(pdwUniqueID[i] >> 16);
+		id[i*4+2] = (uint8_t)(pdwUniqueID[i] >> 8);
+		id[i*4+3] = (uint8_t)(pdwUniqueID[i] >> 0);
+	}
+
+	/* To stop the Unique Identifier mode, the user needs to send the Stop Read unique Identifier
+	command (SPUI) by writing the Flash Command Register with the SPUI command. */
+	EFC1->EEFC_FCR = (0x5A << 24) | EFC_FCMD_SPUI ;
+
+	/* When the Stop read Unique Unique Identifier command (SPUI) has been performed, the
+	FRDY bit in the Flash Programming Status Register (EEFC_FSR) rises. */
+	do
+	{
+		status = EFC1->EEFC_FSR ;
+	} while ( (status & EEFC_FSR_FRDY) != EEFC_FSR_FRDY );
 #endif
 }
 

--- a/src/ArduinoUniqueID.h
+++ b/src/ArduinoUniqueID.h
@@ -13,8 +13,9 @@
 #endif
 #elif defined(ARDUINO_ARCH_ESP8266)
 #elif defined(ARDUINO_ARCH_ESP32)
+#elif defined(ARDUINO_ARCH_SAM)
 #else
-#error "ArduinoUniqueID only works on AVR and ESP Architecture"
+#error "ArduinoUniqueID only works on AVR, SAM and ESP Architecture"
 #endif
 
 #if defined(ARDUINO_ARCH_AVR)
@@ -33,6 +34,9 @@
 #elif defined(ARDUINO_ARCH_ESP32)
 #define UniqueIDsize 6
 #define UniqueIDbuffer 8
+#elif defined(ARDUINO_ARCH_SAM)
+#define UniqueIDsize 16
+#define UniqueIDbuffer 16
 #endif
 
 #define UniqueID8 (_UniqueID.id + UniqueIDbuffer - 8)


### PR DESCRIPTION
ArduinoUniqueID now reads the first 128 bits from flash if it's the SAM-series.

Inspiration: https://gist.github.com/pingud98/251fcf22d5c74c2af8515abdd382fd1e and http://forum.arduino.cc/index.php?topic=289190.0

Atmel SAM3X8E ARM Cortex-M3 datasheet: http://ww1.microchip.com/downloads/en/devicedoc/atmel-11057-32-bit-cortex-m3-microcontroller-sam3x-sam3a_datasheet.pdf