### PR TITLE
Nano 33 IoT Example Fix

### DIFF
--- a/examples/ArduinoUniqueID/ArduinoUniqueID.ino
+++ b/examples/ArduinoUniqueID/ArduinoUniqueID.ino
@@ -9,6 +9,7 @@
 void setup()
 {
 	Serial.begin(115200);
+	while(!Serial);
 	UniqueIDdump(Serial);
 	Serial.print("UniqueID: ");
 	for (size_t i = 0; i < UniqueIDsize; i++)

--- a/examples/ArduinoUniqueID8/ArduinoUniqueID8.ino
+++ b/examples/ArduinoUniqueID8/ArduinoUniqueID8.ino
@@ -9,6 +9,7 @@
 void setup()
 {
 	Serial.begin(115200);
+	while(!Serial);
 	UniqueID8dump(Serial);
 	Serial.print("UniqueID: ");
 	for (size_t i = 0; i < 8; i++)


### PR DESCRIPTION
I was able to reproduce #12 on my own Nano 33 IoT. The examples "ArduinoUniqueID" and "ArduinoUniqueID8" do not print anything to the Serial Monitor when uploaded to the board. However, "ArduinoUniqueIDSerialUSB" works perfectly fine.

The fix is to add a simple `while(!Serial);` to the code just after opening the serial port.
I have confirmed that this works by testing it on my Nano 33 IoT.